### PR TITLE
$select support added

### DIFF
--- a/src/Mercato.AspNet.OData.DataTable/EdmBuilder.cs
+++ b/src/Mercato.AspNet.OData.DataTable/EdmBuilder.cs
@@ -21,8 +21,8 @@ namespace Mercato.AspNet.OData.DataTableExtension
 
             EdmModel Output = new EdmModel();
 
-            EdmComplexType DataSourceModel = new EdmComplexType(Namespace, TypeName);
-
+            EdmEntityType DataSourceModel = new EdmEntityType(Namespace, TypeName);
+            
             foreach (DataColumn SourceColumn in sourceTable.Columns)
             {
                 String ColumnName = SourceColumn.ColumnName;
@@ -38,7 +38,7 @@ namespace Mercato.AspNet.OData.DataTableExtension
 
             }
 
-            Output.AddComplexType(Namespace, "DataSource", DataSourceModel);
+            Output.AddEntityType(Namespace, "DataSource", DataSourceModel);
 
             return new Tuple<IEdmModel, IEdmType>(Output, DataSourceModel);
         }

--- a/src/Mercato.AspNet.OData.DataTable/ODataTableFilter.cs
+++ b/src/Mercato.AspNet.OData.DataTable/ODataTableFilter.cs
@@ -43,7 +43,7 @@ namespace Mercato.AspNet.OData.DataTableExtension
                     OutputRows = OutputRows.Skip(criteria.Skip.Value);
                 }
 
-                if(criteria.Top != null)
+                if (criteria.Top != null)
                 {
                     OutputRows = OutputRows.Take(criteria.Top.Value);
                 }
@@ -52,7 +52,7 @@ namespace Mercato.AspNet.OData.DataTableExtension
                 OutputTable.TableName = sourceData.TableName;
             }
 
-            if(criteria.SelectExpand?.SelectExpandClause?.SelectedItems != null)
+            if (criteria.SelectExpand?.SelectExpandClause?.SelectedItems != null)
             {
                 OutputTable = ApplySelect(OutputTable, criteria.SelectExpand.SelectExpandClause);
             }
@@ -110,17 +110,17 @@ namespace Mercato.AspNet.OData.DataTableExtension
                     SingleValueNode Node = (node as ConvertNode)?.Source;
 
                     return ParseNode(Node);
-                //case QueryNodeKind.SingleValueFunctionCall:
-                //    SingleValueFunctionCallNode FuncNode = node as SingleValueFunctionCallNode;
+                    //case QueryNodeKind.SingleValueFunctionCall:
+                    //    SingleValueFunctionCallNode FuncNode = node as SingleValueFunctionCallNode;
 
-                //    FuncNode.p
+                    //    FuncNode.p
 
-                //    String OperatorFormat = TranslateOperator(BONode.OperatorKind);
+                    //    String OperatorFormat = TranslateOperator(BONode.OperatorKind);
 
 
-                //    return String.Empty;
+                    //    return String.Empty;
 
-                //    break;
+                    //    break;
             }
 
             return String.Empty;
@@ -176,8 +176,8 @@ namespace Mercato.AspNet.OData.DataTableExtension
                 case BinaryOperatorKind.Modulo:
                     Output = "{0} % {1}";
                     break;
-                //case BinaryOperatorKind.Has:
-                //TODO: Implement has operator
+                    //case BinaryOperatorKind.Has:
+                    //TODO: Implement has operator
                     //break;
             }
 
@@ -239,15 +239,42 @@ namespace Mercato.AspNet.OData.DataTableExtension
                 return source;
             }
 
+            List<String> ColumnNames = new List<String>();
+
+            foreach (SelectItem item in selectCriteria.SelectedItems)
+            {
+                if (item is PathSelectItem)
+                {
+                    PathSelectItem PathItem = (PathSelectItem)item;
+
+                    IEnumerable<String> Path = PathItem.SelectedPath.Select(x => x.Identifier.ToUpperInvariant());
+
+                    foreach (String PathIdent in Path)
+                    {
+                        if (!ColumnNames.Contains(PathIdent))
+                        {
+                            ColumnNames.Add(PathIdent);
+                        }
+                    }
+                }
+            }
+
             List<DataColumn> DeleteColumns = new List<DataColumn>();
 
             foreach (DataColumn sourceColumn in source.Columns)
             {
+                if (!ColumnNames.Any(x => String.Equals(x, sourceColumn.ColumnName, StringComparison.InvariantCultureIgnoreCase)))
+                {
+                    DeleteColumns.Add(sourceColumn);
+                }
+            }
 
-                //if(!selectCriteria.SelectedItems.Any(x=>String.Equals(x)))
-                //{
-
-                //}
+            if(DeleteColumns.Count > 0)
+            {
+                foreach (DataColumn Target in DeleteColumns)
+                {
+                    source.Columns.Remove(Target.ColumnName);
+                }
             }
 
             return source;

--- a/src/Mercato.AspNet.OData.DataTable/ODataTableFilter.cs
+++ b/src/Mercato.AspNet.OData.DataTable/ODataTableFilter.cs
@@ -232,6 +232,12 @@ namespace Mercato.AspNet.OData.DataTableExtension
             return Output;
         }
 
+        /// <summary>
+        /// Restricts the output table to only the columns specified in the OData $select parameter
+        /// </summary>
+        /// <param name="source"></param>
+        /// <param name="selectCriteria"></param>
+        /// <returns></returns>
         private static DataTable ApplySelect(DataTable source, SelectExpandClause selectCriteria)
         {
             if (selectCriteria.AllSelected)

--- a/src/Mercato.AspNet.OData.DataTable/ODataTableFilter.cs
+++ b/src/Mercato.AspNet.OData.DataTable/ODataTableFilter.cs
@@ -52,6 +52,11 @@ namespace Mercato.AspNet.OData.DataTableExtension
                 OutputTable.TableName = sourceData.TableName;
             }
 
+            if(criteria.SelectExpand?.SelectExpandClause?.SelectedItems != null)
+            {
+                OutputTable = ApplySelect(OutputTable, criteria.SelectExpand.SelectExpandClause);
+            }
+
             return OutputTable;
         }
 
@@ -227,5 +232,25 @@ namespace Mercato.AspNet.OData.DataTableExtension
             return Output;
         }
 
+        private static DataTable ApplySelect(DataTable source, SelectExpandClause selectCriteria)
+        {
+            if (selectCriteria.AllSelected)
+            {
+                return source;
+            }
+
+            List<DataColumn> DeleteColumns = new List<DataColumn>();
+
+            foreach (DataColumn sourceColumn in source.Columns)
+            {
+
+                //if(!selectCriteria.SelectedItems.Any(x=>String.Equals(x)))
+                //{
+
+                //}
+            }
+
+            return source;
+        }
     }
 }


### PR DESCRIPTION
A rather naiive but working implementation of $select support, returning only data columns specified using standard $select=<item1>,...,<item n> syntax