### PR TITLE
OData header fixes

### DIFF
--- a/src/Mercato.AspNet.OData.DataTable.Demo/Controllers/TestController.cs
+++ b/src/Mercato.AspNet.OData.DataTable.Demo/Controllers/TestController.cs
@@ -17,7 +17,7 @@ using System.Xml;
 
 namespace Mercato.AspNet.OData.DataTableExtension.Demo.Controllers
 {
-    [RoutePrefix("api/v2")]
+    [RoutePrefix("api")]
     public class TestController : ApiController
    {
         [Route("Test")]
@@ -30,13 +30,18 @@ namespace Mercato.AspNet.OData.DataTableExtension.Demo.Controllers
 
             String AddressBase = $"{this.Request.RequestUri.Scheme}://{this.Request.RequestUri.Host}:{this.Request.RequestUri.Port}";
 
-            String EndpointAddress = $"{AddressBase}/api/v2/Test";
-            String MetaDataAddress = $"{AddressBase}/api/v2/$metadata#Test";
+            //Path to this endpoint - used for generating Next links when returning paged data
+            String EndpointAddress = $"{AddressBase}/api/Test";
+            //Path to the metadata for this entity's context, including reference to this specific entity set
+            String MetaDataAddress = $"{AddressBase}/api/$metadata#Test";
 
             ODataReturn ReturnData = new ODataReturn(Output, EndpointAddress, MetaDataAddress);
 
+            //Workaround method to convert data columns that are not based on Edm mappable types - currently only known one is DateTime, which is mapped to DateTimeOffset
             ReturnData.PatchUpValueTypes();
 
+            //Returns a specialised OkNegotiatedContentResult that ensures JSON serialisation, and included the OData-Version header
+            // http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#_Toc31358862
             return ReturnData.GenerateResponseMessage(this);
         }
 
@@ -75,10 +80,6 @@ namespace Mercato.AspNet.OData.DataTableExtension.Demo.Controllers
                     Output.Content.Headers.TryAddWithoutValidation(
                         ODataNegotiatedContentResult.ODataServiceVersionHeader,
                         ODataUtils.ODataVersionToString(ODataVersion.V4));
-
-
-                    //StringContent OutputContent = new StringContent(XmlOutput);
-                    //OutputContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/xml");
 
                     return ResponseMessage(Output);
                 }

--- a/src/Mercato.AspNet.OData.DataTable.Demo/Test/TestData.cs
+++ b/src/Mercato.AspNet.OData.DataTable.Demo/Test/TestData.cs
@@ -9,7 +9,7 @@ namespace Mercato.AspNet.OData.DataTableExtension.Demo
         {
             DataTable Output = new DataTable("Test");
 
-            DataColumn IDColumn = Output.Columns.Add("ID", typeof(Int32));
+            DataColumn IDColumn = Output.Columns.Add("TestID", typeof(Int32));
             Output.Columns.Add("Description", typeof(String));
             Output.Columns.Add("Value", typeof(Decimal));
             Output.Columns.Add("LastUpdated", typeof(DateTime));
@@ -20,7 +20,7 @@ namespace Mercato.AspNet.OData.DataTableExtension.Demo
 
             DataRow NewRow = Output.NewRow();
 
-            NewRow["ID"] = 1;
+            NewRow["TestID"] = 1;
             NewRow["Description"] = "Mark";
             NewRow["Value"] = 1000000;
             NewRow["LastUpdated"] = DateTime.Now.AddMonths(-1);
@@ -31,7 +31,7 @@ namespace Mercato.AspNet.OData.DataTableExtension.Demo
 
             NewRow = Output.NewRow();
 
-            NewRow["ID"] = 2;
+            NewRow["TestID"] = 2;
             NewRow["Description"] = "Neil";
             NewRow["Value"] = 10000000;
             NewRow["LastUpdated"] = DateTime.Now.AddDays(-1);
@@ -42,7 +42,7 @@ namespace Mercato.AspNet.OData.DataTableExtension.Demo
 
             NewRow = Output.NewRow();
 
-            NewRow["ID"] = 3;
+            NewRow["TestID"] = 3;
             NewRow["Description"] = "Tom";
             NewRow["Value"] = 10000;
             NewRow["LastUpdated"] = DateTime.Now.AddDays(-5);
@@ -53,7 +53,7 @@ namespace Mercato.AspNet.OData.DataTableExtension.Demo
 
             NewRow = Output.NewRow();
 
-            NewRow["ID"] = 4;
+            NewRow["TestID"] = 4;
             NewRow["Description"] = "Jamie";
             NewRow["Value"] = 500000;
             NewRow["LastUpdated"] = DateTime.Now.AddDays(-10);
@@ -64,7 +64,7 @@ namespace Mercato.AspNet.OData.DataTableExtension.Demo
             
             NewRow = Output.NewRow();
 
-            NewRow["ID"] = 5;
+            NewRow["TestID"] = 5;
             NewRow["Description"] = "Neil";
             NewRow["Value"] = 500000;
             NewRow["LastUpdated"] = DateTime.Now.AddDays(-10);

--- a/src/Mercato.AspNet.OData.DataTable/EdmBuilder.cs
+++ b/src/Mercato.AspNet.OData.DataTable/EdmBuilder.cs
@@ -16,7 +16,7 @@ namespace Mercato.AspNet.OData.DataTableExtension
         /// </summary>
         /// <param name="sourceTable"></param>
         /// <returns></returns>
-        public static Tuple<IEdmModel, IEdmType> BuildEdmModel(this DataTable sourceTable, String entityName = null)
+        public static Tuple<IEdmModel, IEdmType> BuildEdmModel(this DataTable sourceTable, String entityName = null, String entitySetName = null)
         {
             String Namespace = "Dynamic";
             String TypeName = sourceTable.TableName;
@@ -56,6 +56,13 @@ namespace Mercato.AspNet.OData.DataTableExtension
             }
 
             Output.AddElement(DataSourceModel);
+
+            if(!String.IsNullOrWhiteSpace(entitySetName))
+            {
+                EdmEntityContainer OutputContainer = Output.AddEntityContainer("Dynamic", "Test");
+
+                OutputContainer.AddEntitySet(entitySetName, DataSourceModel);
+            }
 
             return new Tuple<IEdmModel, IEdmType>(Output, DataSourceModel);
         }

--- a/src/Mercato.AspNet.OData.DataTable/Mercato.AspNet.OData.DataTable.csproj
+++ b/src/Mercato.AspNet.OData.DataTable/Mercato.AspNet.OData.DataTable.csproj
@@ -35,7 +35,6 @@ This is an initial implementation to allow for core functionality in cases where
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNet.OData" Version="7.5.8" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.7" />
     <PackageReference Include="Microsoft.OData.Core" Version="7.9.0" />
     <PackageReference Include="Microsoft.OData.Edm" Version="7.9.0" />
@@ -49,6 +48,10 @@ This is an initial implementation to allow for core functionality in cases where
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\OData_WebApi\src\Microsoft.AspNet.OData\Microsoft.AspNet.OData.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Mercato.AspNet.OData.DataTable/Mercato.AspNet.OData.DataTable.csproj
+++ b/src/Mercato.AspNet.OData.DataTable/Mercato.AspNet.OData.DataTable.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>Mercato.AspNet.OData.DataTableExtension</RootNamespace>
     <AssemblyName>Mercato.AspNet.OData.DataTableExtension</AssemblyName>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>1.2.7</Version>
+    <Version>1.2.8</Version>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <Company>Mercato Solutions Ltd</Company>
     <Authors>Mark Middlemist</Authors>
@@ -13,8 +13,9 @@
     <RepositoryUrl>https://github.com/delradie/DataTableOData</RepositoryUrl>
     <PackageProjectUrl>https://github.com/delradie/DataTableOData</PackageProjectUrl>
 	<Title>ADO.Net DataTable OData support</Title>
-    <AssemblyVersion>1.2.7.16</AssemblyVersion>
-    <PackageReleaseNotes>v1.2.7 - Structure fixes
+    <AssemblyVersion>1.2.8.17</AssemblyVersion>
+    <PackageReleaseNotes>v1.2.8 - Updates to support returning HTTP responses with the correct OData headers
+v1.2.7 - Structure fixes
 v1.2.6 - DateTime metadata conversion to DateTimeOffset rather than Date
 v1.2.5 - Dependency updates
 v1.2.4 - Dependency updates
@@ -26,7 +27,7 @@ v1.1.6 - Updated RowFilter generation to allow GUID input to be used correctly
 v1.1.5 - Specifically set vendorExtension to null in swagger properties
 v1.1.1 - ODataParametersSwaggerDefinition class added to aid adding OData parameter information via Swashbuckle
 v1.0.1 - Simplified extension method added for DataTable</PackageReleaseNotes>
-    <FileVersion>1.2.7.16</FileVersion>
+    <FileVersion>1.2.8.17</FileVersion>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <Description>Adds support for OData query syntax over ADO.Net DataTables in WebApi projects.
 This is an initial implementation to allow for core functionality in cases where there is no fixed structure for the datatable at design time, meaning that use of the standard Microsoft.AspNet.OData nuget is precluded by the lack of a fixed EdmModel or underlying Entity source.</Description>

--- a/src/Mercato.AspNet.OData.DataTable/Mercato.AspNet.OData.DataTable.csproj
+++ b/src/Mercato.AspNet.OData.DataTable/Mercato.AspNet.OData.DataTable.csproj
@@ -35,6 +35,7 @@ This is an initial implementation to allow for core functionality in cases where
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNet.OData" Version="7.5.8" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.7" />
     <PackageReference Include="Microsoft.OData.Core" Version="7.9.0" />
     <PackageReference Include="Microsoft.OData.Edm" Version="7.9.0" />
@@ -50,8 +51,5 @@ This is an initial implementation to allow for core functionality in cases where
     </None>
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\OData_WebApi\src\Microsoft.AspNet.OData\Microsoft.AspNet.OData.csproj" />
-  </ItemGroup>
 
 </Project>

--- a/src/Mercato.AspNet.OData.DataTable/ODataNegotiatedContentResult.cs
+++ b/src/Mercato.AspNet.OData.DataTable/ODataNegotiatedContentResult.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Formatting;
+using System.Net.Http.Headers;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,7 +14,7 @@ using System.Web.Http.Results;
 
 namespace Mercato.AspNet.OData.DataTableExtension
 {
-    internal class ODataNegotiatedContentResult : OkNegotiatedContentResult<ODataReturn>
+    public class ODataNegotiatedContentResult : OkNegotiatedContentResult<ODataReturn>
     {
         public ODataNegotiatedContentResult(ODataReturn content, ApiController controller) 
         :base(content, controller){ }
@@ -22,10 +23,12 @@ namespace Mercato.AspNet.OData.DataTableExtension
      : base(content, contentNegotiator, request, formatters) { }
 
 
-        internal const string ODataServiceVersionHeader = "OData-Version";
+        public const string ODataServiceVersionHeader = "OData-Version";
 
         public override async Task<HttpResponseMessage> ExecuteAsync(CancellationToken cancellationToken)
         {
+            base.Request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
             HttpResponseMessage response = await base.ExecuteAsync(cancellationToken);
 
             response.Headers.TryAddWithoutValidation(

--- a/src/Mercato.AspNet.OData.DataTable/ODataNegotiatedContentResult.cs
+++ b/src/Mercato.AspNet.OData.DataTable/ODataNegotiatedContentResult.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.AspNet.OData.Routing;
+using Microsoft.OData;
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Formatting;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web.Http;
+using System.Web.Http.Results;
+
+namespace Mercato.AspNet.OData.DataTableExtension
+{
+    internal class ODataNegotiatedContentResult : OkNegotiatedContentResult<ODataReturn>
+    {
+        public ODataNegotiatedContentResult(ODataReturn content, ApiController controller) 
+        :base(content, controller){ }
+
+        public ODataNegotiatedContentResult(ODataReturn content, IContentNegotiator contentNegotiator, HttpRequestMessage request, IEnumerable<MediaTypeFormatter> formatters)
+     : base(content, contentNegotiator, request, formatters) { }
+
+
+        internal const string ODataServiceVersionHeader = "OData-Version";
+
+        public override async Task<HttpResponseMessage> ExecuteAsync(CancellationToken cancellationToken)
+        {
+            HttpResponseMessage response = await base.ExecuteAsync(cancellationToken);
+
+            response.Headers.TryAddWithoutValidation(
+                ODataServiceVersionHeader,
+                ODataUtils.ODataVersionToString(ODataVersion.V4));
+
+            return response;
+        }
+    }
+}

--- a/src/Mercato.AspNet.OData.DataTable/ODataReturn.cs
+++ b/src/Mercato.AspNet.OData.DataTable/ODataReturn.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Web.Http;
 
 namespace Mercato.AspNet.OData.DataTableExtension
 {
@@ -119,6 +120,11 @@ namespace Mercato.AspNet.OData.DataTableExtension
             {
                 throw;
             }
+        }
+
+        public IHttpActionResult GenerateResponseMessage(ApiController controller)
+        {
+            return new ODataNegotiatedContentResult(this, controller);
         }
     }
 }


### PR DESCRIPTION
Updated to better adhere to the documented OData v4 standard

Primary update from previous version is the inclusion of the "OData-Version" HTTP header (http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#_Toc31358862 ) on responses for both data and metadata endpoints